### PR TITLE
🔧 Make it easier to build and test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: docker-practice/actions-setup-docker@master
-      - uses: earthly/actions-setup@v1
-        with:
-          version: "latest"
-      - run: earthly --ci --push +test --BUNDLE=${{ matrix.bundles }}
+      - run: ./earthly.sh --ci --push +test --BUNDLE=${{ matrix.bundles }}

--- a/README.md
+++ b/README.md
@@ -125,7 +125,9 @@ If you want to build and test a bundle, you can use earthly by running the follo
 
 ```
 # build
-earthly +build --BUNDLE=<bundle-name>
+./earthly.sh +build --BUNDLE=<bundle-name>
 # test
-earthly +test --BUNDLE=<bundle-name>
+./earthly.sh +test --BUNDLE=<bundle-name>
 ```
+
+We also provide a version of the `earthly.sh` script for Windows (`eartly.ps1`).

--- a/earthly.ps1
+++ b/earthly.ps1
@@ -1,0 +1,1 @@
+docker run --privileged -v /var/run/docker.sock:/var/run/docker.sock --rm -t -v ${pwd}:/workspace -v earthly-tmp:/tmp/earthly:rw earthly/earthly:v0.6.30 --allow-privileged @args

--- a/earthly.sh
+++ b/earthly.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker run --privileged -v /var/run/docker.sock:/var/run/docker.sock --rm -t -v $(pwd):/workspace -v earthly-tmp:/tmp/earthly:rw earthly/earthly:v0.6.30 --allow-privileged $@

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,18 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": [
+        "^earthly\\.(sh|ps1)$"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "earthly/earthly",
+      "matchStrings": [
+        "earthly\\/earthly:(?<currentValue>.*?)\\s"
+      ],
+      "versioningTemplate": "semver-coerced"
+    }
   ]
 }


### PR DESCRIPTION
This copies the `earthly.ps1` and `earthly.sh` files so nobody contributing needs to have Earthly installed.  It also updates CI to use this script to ensure that what contributors use works (except for Windows).