### PR TITLE
🔧 Lint the renovate config to ensure it is valid

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,18 @@
+name: Lint
+on:
+ push:
+   branches:
+     - main
+ pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Run Lint checks
+        run: |
+          ./earthly.sh +lint

--- a/Earthfile
+++ b/Earthfile
@@ -4,6 +4,9 @@ ARG BUNDLE
 ARG VERSION="latest"
 ARG IMAGE_REPOSITORY=quay.io/kairos/community-bundles
 
+# renovate: datasource=docker depName=renovate/renovate versioning=docker
+ARG RENOVATE_VERSION=34
+
 version:
     FROM alpine
     RUN apk add git
@@ -34,3 +37,13 @@ test:
     RUN cd tests && \ 
         go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo && \
         ginkgo --label-filter="${BUNDLE}" -v ./...
+
+renovate-validate:
+    ARG RENOVATE_VERSION
+    FROM renovate/renovate:$RENOVATE_VERSION
+    WORKDIR /usr/src/app
+    COPY renovate.json .
+    RUN renovate-config-validator
+
+lint:
+    BUILD +renovate-validate

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,15 @@
   "regexManagers": [
     {
       "fileMatch": [
+        "^Earthfile$"
+      ],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>.*?)\\s+depName=(?<depName>.*?)(\\s+versioning=(?<versioning>.*?))?\\sARG\\s+.+_VERSION=(?<currentValue>.*?)\\s"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{versioning}}{{else}}semver{{/if}}"
+    },
+    {
+      "fileMatch": [
         "^earthly\\.(sh|ps1)$"
       ],
       "datasourceTemplate": "docker",


### PR DESCRIPTION
This adds a new GitHub workflow to run lint, as well as a new target in the `Earthfile` to execute our lint checks.