### PR TITLE
✨ Add a bundle for Project Calico

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,6 +19,7 @@ jobs:
     strategy:
       matrix:
         bundles:
+          - calico
           - cert-manager
           - kubevirt
           - metallb

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         bundles:
+          - calico
           - cert-manager
           - kubevirt
           - metallb

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ bundles:
 - targets:
   - run://quay.io/kairos/community-bundles:calico_latest
 
-# Specify cert-manager settings
+# Specify calico settings
 calico:
   version: 3.25.0
 ```

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Please note that these community bundles are not officially supported and are pr
 
 - [Usage](#usage)
 - [Bundles](#bundles)
+  - [Calico](#calico)
   - [Cert-Manager](#cert-manager)
   - [Kubevirt](#kubevirt)
   - [MetalLB](#metallb)
@@ -60,6 +61,25 @@ k3s:
 ```
 
 ## Bundles
+
+### Calico
+
+The calico bundle deploys [Project Calico](https://docs.tigera.io/calico/latest/about/).
+
+To configure the bundle, use the `calico` block:
+
+```yaml
+#cloud-config
+
+# Specify the bundle to use
+bundles:
+- targets:
+  - run://quay.io/kairos/community-bundles:calico_latest
+
+# Specify cert-manager settings
+calico:
+  version: 3.25.0
+```
 
 ### Cert-manager
 

--- a/calico/Dockerfile
+++ b/calico/Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine as build
+FROM scratch
+COPY ./run.sh /
+COPY ./assets /assets

--- a/calico/assets/calico.yaml
+++ b/calico/assets/calico.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tigera-operator
+---
+apiVersion: helm.cattle.io/v1
+kind: HelmChart
+metadata:
+  name: calico
+  namespace: tigera-operator
+spec:
+  chart: calico
+  repo: https://docs.tigera.io/calico/charts
+  version: "@VERSION@"

--- a/calico/run.sh
+++ b/calico/run.sh
@@ -13,6 +13,7 @@ getConfig() {
     echo   
 }
 
+# renovate: depName=calico repoUrl=https://docs.tigera.io/calico/charts
 VERSION="3.25.0"
 
 templ() {

--- a/calico/run.sh
+++ b/calico/run.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -ex
+
+K3S_MANIFEST_DIR=${K3S_MANIFEST_DIR:-/var/lib/rancher/k3s/server/manifests/}
+
+getConfig() {
+    local l=$1
+    key=$(kairos-agent config get $l | tr -d '\n')
+    if [ "$key" != "null" ]; then
+     echo $key
+    fi 
+    echo   
+}
+
+VERSION="3.25.0"
+
+templ() {
+    local file="$3"
+    local value="$2"
+    local sentinel="$1"
+    sed -i "s/@${sentinel}@/${value}/g" ${file}
+}
+
+readConfig() {
+    _version=$(getConfig calico.version)
+    if [ "$_version" != "" ]; then
+        VERSION=$_version
+    fi
+}
+
+mkdir -p $K3S_MANIFEST_DIR
+
+readConfig
+
+# Copy manifests, and template them
+for FILE in assets/*; do 
+  templ "VERSION" "${VERSION}" $FILE
+done;
+
+cp -rf assets/* $K3S_MANIFEST_DIR

--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,15 @@
         "earthly\\/earthly:(?<currentValue>.*?)\\s"
       ],
       "versioningTemplate": "semver-coerced"
+    },
+    {
+      "datasourceTemplate": "helm",
+      "fileMatch": [
+        "^run\\.sh$"
+      ],
+      "matchStrings": [
+        "#\\s*renovate:\\s*depName=(?<depName>.*?)(\\s+repoUrl=(?<registryUrl>.*?))?\\sVERSION=\\\"(?<currentValue>.*?)\\\"\\s"
+      ]
     }
   ]
 }

--- a/tests/calico_test.go
+++ b/tests/calico_test.go
@@ -1,0 +1,40 @@
+package bundles_test
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("calico test", Label("calico"), func() {
+
+	BeforeEach(func() {
+		prepareBundle()
+	})
+	AfterEach(func() {
+		cleanBundle()
+	})
+
+	It("Deploy calico with default version", func() {
+		runBundle()
+		dat, err := os.ReadFile(filepath.Join("/var/lib/rancher/k3s/server/manifests", "calico.yaml"))
+		content := string(dat)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(content).To(ContainSubstring("version: \"3.25.0\""))
+	})
+
+	It("Specifiy version for calico", func() {
+		err := os.WriteFile("/oem/foo.yaml", []byte(`#cloud-config
+calico:
+ version: 1`), 0655)
+		Expect(err).ToNot(HaveOccurred())
+
+		runBundle()
+		dat, err := os.ReadFile(filepath.Join("/var/lib/rancher/k3s/server/manifests", "calico.yaml"))
+		content := string(dat)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(content).To(ContainSubstring("version: \"1\""))
+	})
+})


### PR DESCRIPTION
This adds a bundle for Project Calico, and allows the configuration of the version to be installed.  The version we install by default is managed by renovate.

This technically addresses https://github.com/kairos-io/kairos/issues/640, but I think it is insufficient for now, as we should allow many more configuration options before considering it done.