### PR TITLE
Fix renovate regexManager for Helm charts in `run.sh` files

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -30,7 +30,7 @@
         "^run\\.sh$"
       ],
       "matchStrings": [
-        "#\\s*renovate:\\s*depName=(?<depName>.*?)(\\s+repoUrl=(?<registryUrl>.*?))?\\sVERSION=\\\"(?<currentValue>.*?)\\\"\\s"
+        "#\\s*renovate:\\s*depName=(?<depName>.*?)(\\s+repoUrl=(?<registryUrl>.*?))?\\s([A-Z0-9_]*)VERSION=\"(?<currentValue>.*?)\"\\s"
       ]
     }
   ]


### PR DESCRIPTION
This addresses two issues:
1) The double quotes around the version were improperly escaped, which I think is why nothing was showing up in these files in the renovate dashboard issue.
2) 8131723dfc5859856814cc7eacad26d3fb4bf572 added a new syntax that would never be picked up by the previous regular expression.

Tested with https://regex101.com/r/KogyoF/1