### PR TITLE
Allow specifying values during install of Project Calico

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,20 @@ bundles:
 
 # Specify calico settings
 calico:
+  values:
+    installation:
+      cni:
+        type: Calico
+      calicoNetwork:
+        bgp: Disabled
+      ipPools:
+        - cidr: 10.244.0.0/16
+          encapsulation: VXLAN
   version: 3.25.0
 ```
+
+Note that specifying `values` and `version` are optional.  Specifying `values` allows you to
+[customize the Helm Chart](https://docs.tigera.io/calico/latest/getting-started/kubernetes/helm#customize-the-helm-chart).
 
 ### Cert-manager
 

--- a/calico/assets/calico.yaml
+++ b/calico/assets/calico.yaml
@@ -11,4 +11,6 @@ metadata:
 spec:
   chart: calico
   repo: https://docs.tigera.io/calico/charts
+  valuesContent: |-
+    @VALUES@
   version: "@VERSION@"

--- a/calico/run.sh
+++ b/calico/run.sh
@@ -4,26 +4,34 @@ set -ex
 
 K3S_MANIFEST_DIR=${K3S_MANIFEST_DIR:-/var/lib/rancher/k3s/server/manifests/}
 
+
 getConfig() {
-    local l=$1
-    key=$(kairos-agent config get $l | tr -d '\n')
-    if [ "$key" != "null" ]; then
-     echo $key
+    local key=$1
+    _value=$(kairos-agent config get "${key} | @json" | tr -d '\n')
+    # Remove the quotes wrapping the value.
+    _value=${_value:1:${#_value}-2}
+    if [ "${_value}" != "null" ]; then
+     echo "${_value}"
     fi 
     echo   
 }
 
+VALUES="{}"
 # renovate: depName=calico repoUrl=https://docs.tigera.io/calico/charts
 VERSION="3.25.0"
 
 templ() {
     local file="$3"
-    local value="$2"
-    local sentinel="$1"
+    local value=$2
+    local sentinel=$1
     sed -i "s/@${sentinel}@/${value}/g" ${file}
 }
 
 readConfig() {
+    _values=$(getConfig calico.values)
+    if [ "$_values" != "" ]; then
+        VALUES=$_values
+    fi
     _version=$(getConfig calico.version)
     if [ "$_version" != "" ]; then
         VERSION=$_version
@@ -36,6 +44,7 @@ readConfig
 
 # Copy manifests, and template them
 for FILE in assets/*; do 
+  templ "VALUES" "${VALUES}" "${FILE}"
   templ "VERSION" "${VERSION}" $FILE
 done;
 

--- a/tests/calico_test.go
+++ b/tests/calico_test.go
@@ -37,4 +37,29 @@ calico:
 		Expect(err).ToNot(HaveOccurred())
 		Expect(content).To(ContainSubstring("version: \"1\""))
 	})
+
+	It("Deploy calico with default values", func() {
+		runBundle()
+		dat, err := os.ReadFile(filepath.Join("/var/lib/rancher/k3s/server/manifests", "calico.yaml"))
+		content := string(dat)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(content).To(ContainSubstring("valuesContent: |-\n    {}"))
+	})
+
+	It("Specifiy installation values for calico", func() {
+		err := os.WriteFile("/oem/foo.yaml", []byte(`#cloud-config
+calico:
+ values:
+  installation:
+   calicoNetwork:
+    bgp: Disabled
+`), 0655)
+		Expect(err).ToNot(HaveOccurred())
+
+		runBundle()
+		dat, err := os.ReadFile(filepath.Join("/var/lib/rancher/k3s/server/manifests", "calico.yaml"))
+		content := string(dat)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(content).To(ContainSubstring("valuesContent: |-\n    {\"installation\":{\"calicoNetwork\":{\"bgp\":\"Disabled\"}}}"))
+	})
 })


### PR DESCRIPTION
This takes advantage of the CRD in k3s that allows us to [pass the values](https://docs.k3s.io/helm#helmchart-field-definitions) that will allow someone to [customize the Helm chart](https://docs.tigera.io/calico/latest/getting-started/kubernetes/helm#customize-the-helm-chart).