### PR TITLE
🔧 Shellcheck

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -6,6 +6,8 @@ ARG IMAGE_REPOSITORY=quay.io/kairos/community-bundles
 
 # renovate: datasource=docker depName=renovate/renovate versioning=docker
 ARG RENOVATE_VERSION=34
+# renovate: datasource=docker depName=koalaman/shellcheck-alpine versioning=docker
+ARG SHELLCHECK_VERSION=v0.9.0
 
 version:
     FROM alpine
@@ -45,5 +47,13 @@ renovate-validate:
     COPY renovate.json .
     RUN renovate-config-validator
 
+shellcheck-lint:
+    ARG SHELLCHECK_VERSION
+    FROM koalaman/shellcheck-alpine:$SHELLCHECK_VERSION
+    WORKDIR /mnt
+    COPY . .
+    RUN find . -name "*.sh" -print | xargs -r -n1 shellcheck
+
 lint:
     BUILD +renovate-validate
+    BUILD +shellcheck-lint

--- a/calico/run.sh
+++ b/calico/run.sh
@@ -24,7 +24,7 @@ templ() {
     local file="$3"
     local value=$2
     local sentinel=$1
-    sed -i "s/@${sentinel}@/${value}/g" ${file}
+    sed -i "s/@${sentinel}@/${value}/g" "${file}"
 }
 
 readConfig() {
@@ -38,14 +38,14 @@ readConfig() {
     fi
 }
 
-mkdir -p $K3S_MANIFEST_DIR
+mkdir -p "${K3S_MANIFEST_DIR}"
 
 readConfig
 
 # Copy manifests, and template them
 for FILE in assets/*; do 
   templ "VALUES" "${VALUES}" "${FILE}"
-  templ "VERSION" "${VERSION}" $FILE
+  templ "VERSION" "${VERSION}" "${FILE}"
 done;
 
-cp -rf assets/* $K3S_MANIFEST_DIR
+cp -rf assets/* "${K3S_MANIFEST_DIR}"

--- a/cert-manager/run.sh
+++ b/cert-manager/run.sh
@@ -6,9 +6,9 @@ K3S_MANIFEST_DIR=${K3S_MANIFEST_DIR:-/var/lib/rancher/k3s/server/manifests/}
 
 getConfig() {
     local l="$1"
-    key=$(kairos-agent config get "$l" | tr -d '\n')
+    key=$(kairos-agent config get "${l}" | tr -d '\n')
     if [ "$key" != "null" ]; then
-     echo $key
+     echo "${key}"
     fi 
     echo   
 }
@@ -29,8 +29,8 @@ readConfig() {
     fi
 }
 
-mkdir -p $K3S_MANIFEST_DIR
+mkdir -p "${K3S_MANIFEST_DIR}"
 
 readConfig
 
-cp -rf assets/cert-manager-$VERSION.yaml $K3S_MANIFEST_DIR/cert-manager.yaml
+cp -rf "assets/cert-manager-${VERSION}.yaml" "${K3S_MANIFEST_DIR}/cert-manager.yaml"

--- a/earthly.sh
+++ b/earthly.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker run --privileged -v /var/run/docker.sock:/var/run/docker.sock --rm -t -v $(pwd):/workspace -v earthly-tmp:/tmp/earthly:rw earthly/earthly:v0.7.0 --allow-privileged $@
+docker run --privileged -v /var/run/docker.sock:/var/run/docker.sock --rm -t -v "$(pwd)":/workspace -v earthly-tmp:/tmp/earthly:rw earthly/earthly:v0.7.0 --allow-privileged "$@"

--- a/kairos/run.sh
+++ b/kairos/run.sh
@@ -6,9 +6,9 @@ K3S_MANIFEST_DIR=${K3S_MANIFEST_DIR:-/var/lib/rancher/k3s/server/manifests/}
 
 getConfig() {
     local l=$1
-    key=$(kairos-agent config get $l | tr -d '\n')
+    key=$(kairos-agent config get "${l}" | tr -d '\n')
     if [ "$key" != "null" ]; then
-     echo $key
+     echo "${key}"
     fi 
     echo   
 }
@@ -29,7 +29,7 @@ templ() {
     local file="$3"
     local value="$2"
     local sentinel="$1"
-    sed -i "s/@${sentinel}@/${value}/g" ${file}
+    sed -i "s/@${sentinel}@/${value}/g" "${file}"
 }
 
 readConfig() {
@@ -63,32 +63,32 @@ readConfig() {
     fi
 }
 
-mkdir -p $K3S_MANIFEST_DIR
+mkdir -p "${K3S_MANIFEST_DIR}"
 
 readConfig
 
 # Copy manifests, and template them
 
 templ "VERSION" "${CRDS_VERSION}" assets/crd.yaml
-cp -rf assets/crd.yaml $K3S_MANIFEST_DIR/kairos-crds.yaml
+cp -rf assets/crd.yaml "${K3S_MANIFEST_DIR}/kairos-crds.yaml"
 
 if [ "$ENTANGLE_ENABLE" == "true" ]; then
     SRC="assets/entangle.yaml"
     FILE=$K3S_MANIFEST_DIR/kairos-entangle.yaml
-    templ "VERSION" "${ENTANGLE_VERSION}" $SRC
-    cp -rf $SRC $FILE
+    templ "VERSION" "${ENTANGLE_VERSION}" "${SRC}"
+    cp -rf "${SRC}" "${FILE}"
 fi
 
 if [ "$ENTANGLEPROXY_ENABLE" == "true" ]; then
     SRC="assets/entangle-proxy.yaml"
     FILE=$K3S_MANIFEST_DIR/kairos-entangle-proxy.yaml
-    templ "VERSION" "${ENTANGLEPROXY_VERSION}" $SRC
-    cp -rf $SRC $FILE
+    templ "VERSION" "${ENTANGLEPROXY_VERSION}" "${SRC}"
+    cp -rf "${SRC}" "${FILE}"
 fi
 
 if [ "$OSBUILDER_ENABLE" == "true" ]; then
     SRC="assets/osbuilder.yaml"
-    FILE=$K3S_MANIFEST_DIR/kairos-osbuilder.yaml
-    templ "VERSION" "${OSBUILDER_VERSION}" $SRC
-    cp -rf $SRC $FILE
+    FILE="${K3S_MANIFEST_DIR}/kairos-osbuilder.yaml"
+    templ "VERSION" "${OSBUILDER_VERSION}" "${SRC}"
+    cp -rf "${SRC}" "${FILE}"
 fi

--- a/kubevirt/run.sh
+++ b/kubevirt/run.sh
@@ -6,9 +6,9 @@ K3S_MANIFEST_DIR=${K3S_MANIFEST_DIR:-/var/lib/rancher/k3s/server/manifests/}
 
 getConfig() {
     local l=$1
-    key=$(kairos-agent config get $l | tr -d '\n')
+    key=$(kairos-agent config get "${l}" | tr -d '\n')
     if [ "$key" != "null" ]; then
-     echo $key
+     echo "${key}"
     fi 
     echo   
 }
@@ -19,7 +19,7 @@ templ() {
     local file="$3"
     local value="$2"
     local sentinel="$1"
-    sed -i "s/@${sentinel}@/${value}/g" ${file}
+    sed -i "s/@${sentinel}@/${value}/g" "${file}"
 }
 
 readConfig() {
@@ -29,13 +29,13 @@ readConfig() {
     fi
 }
 
-mkdir -p $K3S_MANIFEST_DIR
+mkdir -p "${K3S_MANIFEST_DIR}"
 
 readConfig
 
 # Copy manifests from kubevirt
-cp -rf assets/* $K3S_MANIFEST_DIR
+cp -rf assets/* "${K3S_MANIFEST_DIR}"
 
 if [ "$KUBEVIRT_MANAGER" == "true" ]; then
-    cp -rf kubevirt-manager-manifests/* $K3S_MANIFEST_DIR
+    cp -rf kubevirt-manager-manifests/* "${K3S_MANIFEST_DIR}"
 fi

--- a/metallb/run.sh
+++ b/metallb/run.sh
@@ -6,9 +6,9 @@ K3S_MANIFEST_DIR=${K3S_MANIFEST_DIR:-/var/lib/rancher/k3s/server/manifests/}
 
 getConfig() {
     local l=$1
-    key=$(kairos-agent config get $l | tr -d '\n')
+    key=$(kairos-agent config get "${l}" | tr -d '\n')
     if [ "$key" != "null" ]; then
-     echo $key
+     echo "${key}"
     fi 
     echo   
 }
@@ -20,7 +20,7 @@ templ() {
     local file="$3"
     local value="$2"
     local sentinel="$1"
-    sed -i "s/@${sentinel}@/${value}/g" ${file}
+    sed -i "s/@${sentinel}@/${value}/g" "${file}"
 }
 
 readConfig() {
@@ -34,14 +34,14 @@ readConfig() {
     fi
 }
 
-mkdir -p $K3S_MANIFEST_DIR
+mkdir -p "${K3S_MANIFEST_DIR}"
 
 readConfig
 
 # Copy manifests, and template them
 for FILE in assets/*; do 
-  templ "VERSION" "${VERSION}" $FILE
-  templ "ADDRESS_POOL" "${ADDRESS_POOL}" $FILE
+  templ "VERSION" "${VERSION}" "${FILE}"
+  templ "ADDRESS_POOL" "${ADDRESS_POOL}" "${FILE}"
 done;
 
-cp -rf assets/* $K3S_MANIFEST_DIR
+cp -rf assets/* "${K3S_MANIFEST_DIR}"

--- a/system-upgrade-controller/run.sh
+++ b/system-upgrade-controller/run.sh
@@ -6,9 +6,9 @@ K3S_MANIFEST_DIR=${K3S_MANIFEST_DIR:-/var/lib/rancher/k3s/server/manifests/}
 
 getConfig() {
     local l="$1"
-    key=$(kairos-agent config get "$l" | tr -d '\n')
+    key=$(kairos-agent config get "${l}" | tr -d '\n')
     if [ "$key" != "null" ]; then
-     echo $key
+     echo "${key}"
     fi 
     echo   
 }
@@ -29,13 +29,13 @@ readConfig() {
     fi
 }
 
-mkdir -p $K3S_MANIFEST_DIR
+mkdir -p "${K3S_MANIFEST_DIR}"
 
 readConfig
 
 # Copy manifests, and template them
 for FILE in assets/*; do 
-  templ "VERSION" "${VERSION}" $FILE
+  templ "VERSION" "${VERSION}" "${FILE}"
 done;
 
-cp -rf assets/* $K3S_MANIFEST_DIR
+cp -rf assets/* "${K3S_MANIFEST_DIR}"


### PR DESCRIPTION
This closes #7 by adding the `shellcheck` linter to the build process, and fixing all existing errors.