### PR TITLE
🔧 Fix renovate file matching pattern

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,7 +27,7 @@
     {
       "datasourceTemplate": "helm",
       "fileMatch": [
-        "^run\\.sh$"
+        "^.+/run\\.sh$"
       ],
       "matchStrings": [
         "#\\s*renovate:\\s*depName=(?<depName>.*?)(\\s+repoUrl=(?<registryUrl>.*?))?\\s([A-Z0-9_]*)VERSION=\"(?<currentValue>.*?)\"\\s"


### PR DESCRIPTION
It was not super obvious, but it appears that it matches the full path, which means that none of the `run.sh` files would ever match.  This would explain why they are not showing up in the dependency dashboard.

Tested at https://regex101.com/r/n0FZYa/1