### PR TITLE
Fix calico Bundle

### DIFF
--- a/calico/assets/calico.yaml
+++ b/calico/assets/calico.yaml
@@ -9,7 +9,8 @@ metadata:
   name: calico
   namespace: tigera-operator
 spec:
-  chart: calico
+  name: calico
+  chart: tigera-operator
   repo: https://docs.tigera.io/calico/charts
   valuesContent: |-
     @VALUES@

--- a/calico/run.sh
+++ b/calico/run.sh
@@ -17,7 +17,7 @@ getConfig() {
 }
 
 VALUES="{}"
-# renovate: depName=calico repoUrl=https://docs.tigera.io/calico/charts
+# renovate: depName=tigera-operator repoUrl=https://docs.tigera.io/calico/charts
 VERSION="3.25.0"
 
 templ() {

--- a/tests/calico_test.go
+++ b/tests/calico_test.go
@@ -22,6 +22,7 @@ var _ = Describe("calico test", Label("calico"), func() {
 		dat, err := os.ReadFile(filepath.Join("/var/lib/rancher/k3s/server/manifests", "calico.yaml"))
 		content := string(dat)
 		Expect(err).ToNot(HaveOccurred())
+		// renovate: depName=tigera-operator repoUrl=https://docs.tigera.io/calico/charts
 		Expect(content).To(ContainSubstring("version: \"3.25.0\""))
 	})
 


### PR DESCRIPTION
In the repository, the [chart name is actually `tigera-operator`](https://docs.tigera.io/calico/3.25/getting-started/kubernetes/helm#install-calico), not `calico`.  This also adds a string to the test file to ensure that when the renovate bot comes along, it updates the version in the test file as well.