### PR TITLE
Attempt to capture *test.go files properly with renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -39,7 +39,7 @@
         "^tests/.+_test\\.go$"
       ],
       "matchStrings": [
-        "//\\s*renovate:\\s*depName=(?<depName>.*?)(\\s+repoUrl=(?<registryUrl>.*?))?\\s+.*version: \\\\\\\"(?<currentValue>.*?)\\\\\\\"\\\""
+        "//\\s*renovate:\\s*depName=(?<depName>.*?)(\\s+repoUrl=(?<registryUrl>.*?))?\\s+.*version: \\\"(?<currentValue>.*?)\\\"\""
       ]
     }
   ]


### PR DESCRIPTION
I think that the [code generated by regex101.com](https://regex101.com/r/9yoCsH/1) was overzealous when escaping backslashes in daccb94b6a0cb2890be9b2bb0bfe57760d8c94d4.

I think this fixes the issue, but it's hard to say definitively because I see no way to run renovate on a local copy of a repository to see what it is actually matching, unfortunately.