### PR TITLE
Changed how value is read in flux bootstrap from yaml to allow : char

### DIFF
--- a/flux/flux-bootstrap.sh
+++ b/flux/flux-bootstrap.sh
@@ -53,7 +53,7 @@ declare -a cmdline
 for setting in "${envs[@]}"; do
   if [[ $setting != "null" ]]; then
     env=$(echo "$setting" | cut -d: -f1)
-    value=$(echo "$setting" | cut -d':' -f2 | sed -E 's/^ //g')
+    value=$(echo "$setting" |  sed -n 's/^[^:]*: *//p')
     if [[ "${value}x" != "x" ]]; then
       export "$env"="$value"
     fi
@@ -64,7 +64,7 @@ done
 for setting in "${args[@]}"; do
   if [[ $setting != "null" ]]; then
     arg=$(echo "$setting" | cut -d: -f1)
-    value=$(echo "$setting" | cut -d':' -f2 | sed -E 's/^ //g')
+    value=$(echo "$setting" |  sed -n 's/^[^:]*: *//p')
     if [[ "${value}x" != "x" ]]; then
       cmdline+=("--$arg" "$value")
     fi 

--- a/flux/flux-bootstrap.sh
+++ b/flux/flux-bootstrap.sh
@@ -33,8 +33,10 @@ if flux version &>/dev/null; then
 fi
 
 # Determine what VCS we need to bootstrap
+# Starting in kairos  2.8.15, kairos-agent command returns empty string  instead of "null"
 for vcs in bitbucket_server git github gitlab; do
-  if [[ $(kairos-agent config get flux.$vcs 2>/dev/null) != "null" ]]; then
+  value=$(kairos-agent config get flux.$vcs 2>/dev/null)
+  if [[ $value != "null" && -n $value ]]; then
     version_control=$vcs
     break
   fi


### PR DESCRIPTION
Currently, if the yaml contains ':' character in the value field, it is not properly read by the script. Something like this:

```yaml
#cloud-config
#....
flux:
  git:
    url: https://repository.url.com
```

will fail as the git.url param will be read as https (due to using cut ':' in the script). Whit the small change, it will cut at the first ':' and take the rest of the line.