### PR TITLE
simplify argocd binary name

### DIFF
--- a/argocd/Dockerfile
+++ b/argocd/Dockerfile
@@ -21,5 +21,5 @@ RUN DOWNLOAD_FILE="/tmp/argocd-linux-${TARGETARCH}" && \
 FROM --platform=$BUILDPLATFORM scratch
 ARG TARGETARCH
 COPY ./run.sh /
-COPY --from=build /tmp/argocd-linux-${TARGETARCH} .
+COPY --from=build /tmp/argocd-linux-${TARGETARCH} ./argocd
 COPY ./assets /assets


### PR DESCRIPTION
Instead of calling argocd cli with `argocd-linux-amd64`, use `argocd` as binary name