### PR TITLE
Set argocd cli as executable

### DIFF
--- a/argocd/run.sh
+++ b/argocd/run.sh
@@ -61,3 +61,4 @@ fi
 
 cp -rf assets/* "${K3S_MANIFEST_DIR}"
 cp  argocd-linux-"$SYSTEM_ARCH" $BIN/argocd
+sudo chmod +x $BIN/argocd


### PR DESCRIPTION
I can not run argocd cli because it miss exe permission.
This PR fix this issue 