### PR TITLE
Set arm64 as default for arch

### DIFF
--- a/argocd/run.sh
+++ b/argocd/run.sh
@@ -54,9 +54,8 @@ ARCH=$(uname -m)
 if [ "$ARCH" == "x86_64" ]; then
     SYSTEM_ARCH="amd64"
 else
-    if [ "$ARCH" == "aarch64" ]; then
-        SYSTEM_ARCH="arm64"
-    fi
+    # Default to arm64 because community bundle don't support arm container so uname will always returns x86_64 
+    SYSTEM_ARCH="arm64"
 fi
 
 cp -rf assets/* "${K3S_MANIFEST_DIR}"

--- a/argocd/run.sh
+++ b/argocd/run.sh
@@ -49,13 +49,13 @@ for FILE in assets/*; do
 done;
 
 # get system arch
-ARCH=$(uname -m)
+ARCH=$(uname -m) 
+
+# Default to arm64 because community bundle don't support arm container so uname will always returns x86_64 
+SYSTEM_ARCH="arm64"
 
 if [ "$ARCH" == "x86_64" ]; then
     SYSTEM_ARCH="amd64"
-else
-    # Default to arm64 because community bundle don't support arm container so uname will always returns x86_64 
-    SYSTEM_ARCH="arm64"
 fi
 
 cp -rf assets/* "${K3S_MANIFEST_DIR}"


### PR DESCRIPTION
Ci doesn't support arm container, so set arch default to arm64, to download argocd cli for arm64 from an x86_64 container 