### PR TITLE
Updated tags to latest numbered. Need ARM architecture for RPI4

### DIFF
--- a/kubevirt/assets/cdi-operator.yaml
+++ b/kubevirt/assets/cdi-operator.yaml
@@ -4746,25 +4746,25 @@ spec:
         - name: DEPLOY_CLUSTER_RESOURCES
           value: "true"
         - name: OPERATOR_VERSION
-          value: v1.55.2
+          value: 20250812_6d6517ae7
         - name: CONTROLLER_IMAGE
-          value: quay.io/kubevirt/cdi-controller:v1.55.2
+          value: quay.io/kubevirt/cdi-controller:v1.63.0
         - name: IMPORTER_IMAGE
-          value: quay.io/kubevirt/cdi-importer:v1.55.2
+          value: quay.io/kubevirt/cdi-importer:v1.63.0
         - name: CLONER_IMAGE
-          value: quay.io/kubevirt/cdi-cloner:v1.55.2
+          value: quay.io/kubevirt/cdi-cloner:v1.63.0
         - name: APISERVER_IMAGE
-          value: quay.io/kubevirt/cdi-apiserver:v1.55.2
+          value: quay.io/kubevirt/cdi-apiserver:v1.63.0
         - name: UPLOAD_SERVER_IMAGE
-          value: quay.io/kubevirt/cdi-uploadserver:v1.55.2
+          value: quay.io/kubevirt/cdi-uploadserver:v1.63.0
         - name: UPLOAD_PROXY_IMAGE
-          value: quay.io/kubevirt/cdi-uploadproxy:v1.55.2
+          value: quay.io/kubevirt/cdi-uploadproxy:v1.63.0
         - name: VERBOSITY
           value: "1"
         - name: PULL_POLICY
           value: IfNotPresent
         - name: MONITORING_NAMESPACE
-        image: quay.io/kubevirt/cdi-operator:v1.55.2
+        image: quay.io/kubevirt/cdi-operator:v1.63.0
         imagePullPolicy: IfNotPresent
         name: cdi-operator
         ports:


### PR DESCRIPTION
This community bundle cannot run on rpi4. 
exec /usr/bin/cdi-operator: exec format error                                                                              │
│ stream closed EOF for cdi/cdi-operator-6b45fc8669-vzx7l (cdi-operator)

After checking with command:

`sudo docker pull quay.io/kubevirt/cdi-operator:v1.55.2 --platform linux/arm64`

Docker returns with 

`WARNING: image with reference quay.io/kubevirt/cdi-operator:v1.55.2 was found but its platform (linux/amd64) does not match the specified platform (linux/arm64)`

This PR updated the image tags I could find and points them to the latest numbered tag, at time of PR

`v1.63.0`

```
sudo docker pull quay.io/kubevirt/cdi-operator:v1.63.0 --platform linux/arm64
v1.63.0: Pulling from kubevirt/cdi-operator
dd1577e06f11: Pull complete 
ea5f4123c698: Pull complete 
Digest: sha256:c01a8d37c14c1ec946c94ee100a563e42d189c89ee26037a2fb07968bd4eca7d
Status: Downloaded newer image for quay.io/kubevirt/cdi-operator:v1.63.0
quay.io/kubevirt/cdi-operator:v1.63.0
charlesrod@node0:~/community-bundles$
```

