### PR TITLE
Enable arm64 builds, starting with Flux

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -43,9 +43,10 @@ jobs:
       REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+      - uses: docker/setup-qemu-action@v3
       - uses: docker-practice/actions-setup-docker@master
       - uses: earthly/actions-setup@v1
         with:
           version: "latest"
       - run: echo $REGISTRY_PASSWORD | docker login -u $REGISTRY_USER --password-stdin $REGISTRY
-      - run: earthly --ci --push +build --BUNDLE=${{ matrix.bundles }}
+      - run: earthly --ci --push --platform=linux/amd64,linux/arm64 +build --BUNDLE=${{ matrix.bundles }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -49,4 +49,4 @@ jobs:
         with:
           version: "latest"
       - run: echo $REGISTRY_PASSWORD | docker login -u $REGISTRY_USER --password-stdin $REGISTRY
-      - run: earthly --ci --push --platform=linux/amd64,linux/arm64 +build --BUNDLE=${{ matrix.bundles }}
+      - run: earthly --ci --push +build-multi --BUNDLE=${{ matrix.bundles }}

--- a/Earthfile
+++ b/Earthfile
@@ -25,6 +25,12 @@ build:
     FROM DOCKERFILE -f ${BUNDLE}/Dockerfile ./${BUNDLE}
     SAVE IMAGE --push $IMAGE_REPOSITORY:${BUNDLE}_${VERSION}
 
+# Multi-platform build target
+build-multi:
+    COPY +version/VERSION ./
+    ARG VERSION=$(cat VERSION)
+    BUILD --platform linux/amd64 --platform linux/arm64 +build --BUNDLE=$BUNDLE
+
 rootfs:
     FROM +build
     SAVE ARTIFACT /. rootfs

--- a/flux/Dockerfile
+++ b/flux/Dockerfile
@@ -1,6 +1,5 @@
 FROM alpine AS build
 # renovate: datasource=github-releases depName=fluxcd/flux2
-# renovate: checksum=sha256
 ENV VERSION=2.6.4
 ENV AMD64_CHECKSUM=9d3e21ad53baa0d5a062e1bd6f1a22d18b95906c682845bca9ffa272cff8a590
 ENV ARM64_CHECKSUM=674e605f527841bb9b50a692b3ce497752cfc81438f85b4d1523d86aca637353

--- a/flux/Dockerfile
+++ b/flux/Dockerfile
@@ -1,17 +1,13 @@
 FROM alpine AS build
 # renovate: datasource=github-releases depName=fluxcd/flux2
-ENV VERSION=2.5.1
-ENV CHECKSUM=f64c85db4b94aefcdf6e0f2825c32573fc2bd234e5489ff332fee62776973ec3
+# renovate: checksum=sha256
+ENV VERSION=2.6.4
+ENV AMD64_CHECKSUM=9d3e21ad53baa0d5a062e1bd6f1a22d18b95906c682845bca9ffa272cff8a590
+ENV ARM64_CHECKSUM=674e605f527841bb9b50a692b3ce497752cfc81438f85b4d1523d86aca637353
+ARG TARGETARCH
 
-ADD https://github.com/fluxcd/flux2/releases/download/v${VERSION}/flux_${VERSION}_linux_amd64.tar.gz /tmp
-RUN DOWNLOAD_FILE="/tmp/flux_${VERSION}_linux_amd64.tar.gz" && \
-    DOWNLOAD_CHECKSUM=$(sha256sum "${DOWNLOAD_FILE}" | awk '{print $1}') && \
-    if [[ ${DOWNLOAD_CHECKSUM} != ${CHECKSUM} ]]; then \
-      echo "Checksum does not match"; \
-      exit 1; \
-    fi && \
-    tar xzf "${DOWNLOAD_FILE}" -C / && \
-    rm "${DOWNLOAD_FILE}"
+COPY flux-download.sh .
+RUN chmod +x flux-download.sh && ./flux-download.sh
 
 FROM scratch
 COPY --from=build flux .

--- a/flux/flux-download.sh
+++ b/flux/flux-download.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -e
+
+if [ "$TARGETARCH" = "amd64" ]; then
+    CHECKSUM="$AMD64_CHECKSUM"
+elif [ "$TARGETARCH" = "arm64" ]; then
+    CHECKSUM="$ARM64_CHECKSUM"
+else
+    echo "Unsupported architecture: $TARGETARCH"
+    exit 1
+fi
+
+DOWNLOAD_FILE="flux_${VERSION}_linux_${TARGETARCH}.tar.gz"
+wget "https://github.com/fluxcd/flux2/releases/download/v${VERSION}/${DOWNLOAD_FILE}" -O "$DOWNLOAD_FILE"
+
+DOWNLOAD_CHECKSUM=$(sha256sum "$DOWNLOAD_FILE" | awk '{print $1}')
+if [ "$DOWNLOAD_CHECKSUM" != "$CHECKSUM" ]; then
+    echo "Checksum verification failed"
+    exit 1
+fi
+
+tar xzf "$DOWNLOAD_FILE"


### PR DESCRIPTION
- Configure the `publish` GitHub action and Earthly to build multi-arch images
- Adapt the Flux bundle to work with arm architectures
- Bump Flux to the latest version
