### PR TITLE
allow to publish versions based on the tag

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -48,5 +48,19 @@ jobs:
       - uses: earthly/actions-setup@v1
         with:
           version: "latest"
+      - name: Determine tag suffix
+        id: tag
+        run: |
+          if [[ $GITHUB_REF == refs/tags/v* ]]; then
+            # Extract version from tag (e.g., refs/tags/v1.0.0 -> v1.0.0)
+            TAG_SUFFIX=${GITHUB_REF#refs/tags/}
+            echo "tag_suffix=$TAG_SUFFIX" >> $GITHUB_OUTPUT
+          elif [[ $GITHUB_REF == refs/heads/main ]]; then
+            echo "tag_suffix=main" >> $GITHUB_OUTPUT
+          else
+            # For other branches, we shouldn't be publishing, but if we do, use branch name
+            TAG_SUFFIX=${GITHUB_REF#refs/heads/}
+            echo "tag_suffix=$TAG_SUFFIX" >> $GITHUB_OUTPUT
+          fi
       - run: echo $REGISTRY_PASSWORD | docker login -u $REGISTRY_USER --password-stdin $REGISTRY
-      - run: earthly --ci --push +build-multi --BUNDLE=${{ matrix.bundles }}
+      - run: earthly --ci --push +build-multi --BUNDLE=${{ matrix.bundles }} --TAG_SUFFIX=${{ steps.tag.outputs.tag_suffix }}

--- a/Earthfile
+++ b/Earthfile
@@ -47,8 +47,7 @@ build-multi:
     BUILD --platform linux/amd64 --platform linux/arm64 +build --BUNDLE=$BUNDLE --TAG_SUFFIX=$TAG_SUFFIX
     
     # If this is a version tag (starts with v), also build latest
-    RUN case "$TAG_SUFFIX" in v*) echo "true" > /tmp/build_latest ;; *) echo "false" > /tmp/build_latest ;; esac
-    IF [ "$(cat /tmp/build_latest)" = "true" ]
+    IF [ "${TAG_SUFFIX#v}" != "$TAG_SUFFIX" ]
         BUILD --platform linux/amd64 --platform linux/arm64 +build-latest --BUNDLE=$BUNDLE
     END
 


### PR DESCRIPTION
Right now main is considered "stable" by releasing always as "_latest", with this change I want to introduce releases, so we can have e.g. v1.0.0 on top of _latest (to not break any scripts out there) and on top of that have "main" as a nightly/dev

I recently had some issues with a package because the container image _latest was already there so it wasn't trying to fetch despite there being a newer _latest. IMO this is problematic beyond this inconvenience so I'd rather have versions if everyone is ok with it