### PR TITLE
Add ability to customize images via cloud-config

### DIFF
--- a/kairos-operator/Dockerfile
+++ b/kairos-operator/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest as build
 
 # renovate: datasource=github-releases depName=kairos-io/kairos-operator
-ENV VERSION=0.0.3
+ENV VERSION=0.0.7
 
 # Install kubectl for kustomize and git
 RUN apk add --no-cache curl git
@@ -16,5 +16,7 @@ RUN git clone --depth 1 --branch v${VERSION} https://github.com/kairos-io/kairos
 RUN cd /tmp/kairos-operator/config/default && kubectl kustomize . > /kairos-operator.yaml
 
 FROM scratch
+COPY --from=build /usr/local/bin/kubectl /assets/kubectl
 COPY --from=build /kairos-operator.yaml /assets/kairos-operator.yaml
-COPY ./run.sh / 
+COPY ./overlays /assets/overlays
+COPY ./run.sh /

--- a/kairos-operator/README.md
+++ b/kairos-operator/README.md
@@ -15,24 +15,31 @@ k3s:
 
 kairosOperator:
   manifest_dir: "/custom/path" # (optional) overrides the previous defaults
+  images: # (optional) override default container images, e.g. for air-gapped environments
+    operator: my-registry.internal/kairos/operator:v0.1.0-beta3 # this field and ones below are optional; only specify what you need to override
+    nodeLabeler: my-registry.internal/kairos/operator-node-labeler:v0.1.0-beta3
+    sentinel: my-registry.internal/busybox:latest
+    nodeOpDefault: my-registry.internal/busybox:latest
 ```
 
 ## Usage
 
 The bundle will:
 
-1. Generate the Kairos operator manifests at build time using `kubectl kustomize`
+1. Generate the Kairos operator manifests at _build_ time using `kubectl kustomize`
 2. Automatically detect whether k0s or k3s is running and deploy to the appropriate manifest directory:
    - **k0s**: `/var/lib/k0s/manifests/kairos-operator/`
    - **k3s**: `/var/lib/rancher/k3s/server/manifests/`
-3. Copy the generated manifests to the detected directory
+3. Apply image overrides from cloud-config (if any) at _install_ time using `kubectl kustomize`
+4. Copy the final manifest to the detected directory
 
 ## Features
 
 - **Multi-distribution support**: Automatically detects and works with both k0s and k3s clusters
 - **Custom manifest directory**: Can be configured to use a custom directory via `manifest_dir`
+- **Image overrides**: Container images can be overridden via cloud-config for air-gapped environments
 - **Build-time generation**: Manifests are generated during Docker build, not runtime
-- **Version management**: Uses version `0.0.2` by default (configurable via Dockerfile)
+- **Version management**: Uses version `0.0.3` by default (configurable via Dockerfile)
 
 ## Configuration Options
 
@@ -49,7 +56,7 @@ You can override the automatic detection by setting configuration options:
 kairosOperator:
   k0s: true
 
-# Force k3s detection  
+# Force k3s detection
 kairosOperator:
   k3s: true
 
@@ -67,9 +74,9 @@ See the [Kairos Operator documentation](https://github.com/kairos-io/kairos-oper
 The bundle is built using Docker. The version can be configured by modifying the `VERSION` environment variable in the Dockerfile:
 
 ```dockerfile
-ENV VERSION=0.0.2
+ENV VERSION=0.0.7
 ```
 
 ### Current Version
 
-The bundle currently uses version `0.0.2` of the Kairos operator. This version is managed via Renovate and can be updated by modifying the Dockerfile. 
+The bundle currently uses version `0.0.7` of the Kairos operator. This version is managed via Renovate and can be updated by modifying the Dockerfile.

--- a/kairos-operator/overlays/env-var-image.yaml
+++ b/kairos-operator/overlays/env-var-image.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: operator-kairos-operator
+  namespace: operator-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        env:
+        - name: @ENV_NAME@
+          value: "@ENV_VALUE@"

--- a/kairos-operator/overlays/kustomization.yaml
+++ b/kairos-operator/overlays/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - kairos-operator.yaml
+patches:

--- a/kairos-operator/overlays/operator-image.yaml
+++ b/kairos-operator/overlays/operator-image.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: operator-kairos-operator
+  namespace: operator-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        image: "@ENV_VALUE@"

--- a/kairos-operator/run.sh
+++ b/kairos-operator/run.sh
@@ -31,9 +31,47 @@ readConfig() {
         echo "- kairosOperator.manifest_dir in the cloud-config."
         exit 1
     fi
+
+    OPERATOR_IMAGE=$(getConfig kairosOperator.images.operator)
+    NODE_LABELER_IMAGE=$(getConfig kairosOperator.images.nodeLabeler)
+    SENTINEL_IMAGE=$(getConfig kairosOperator.images.sentinel)
+    NODEOP_DEFAULT_IMAGE=$(getConfig kairosOperator.images.nodeOpDefault)
+}
+
+processOverlay() {
+    local overlay_file="$1"
+    local env_name="$2"
+    local env_value="$3"
+    local copy_from_env_overlay="$4"
+
+    if [ -z "$env_value" ]; then
+        return
+    fi
+
+    if [ "$copy_from_env_overlay" = true ]; then
+        cp "assets/overlays/env-var-image.yaml" "assets/overlays/${overlay_file}"
+    fi
+
+    sed -i "s|@ENV_NAME@|${env_name}|g" "assets/overlays/${overlay_file}"
+    sed -i "s|@ENV_VALUE@|${env_value}|g" "assets/overlays/${overlay_file}"
+    echo "  - path: ${overlay_file}" >> assets/overlays/kustomization.yaml
+    HAS_OVERLAYS=true
 }
 
 readConfig
 
+HAS_OVERLAYS=false
+
+processOverlay "operator-image.yaml" "OPERATOR_IMAGE" "$OPERATOR_IMAGE"
+processOverlay "operator-env.yaml" "OPERATOR_IMAGE" "$OPERATOR_IMAGE" true
+processOverlay "node-labeler-env.yaml" "NODE_LABELER_IMAGE" "$NODE_LABELER_IMAGE" true
+processOverlay "sentinel-env.yaml" "SENTINEL_IMAGE" "$SENTINEL_IMAGE" true
+processOverlay "nodeop-default-env.yaml" "NODEOP_DEFAULT_IMAGE" "$NODEOP_DEFAULT_IMAGE" true
+
+if [ "$HAS_OVERLAYS" = true ]; then
+    cp assets/kairos-operator.yaml assets/overlays/kairos-operator.yaml
+    assets/kubectl kustomize assets/overlays > assets/kairos-operator.yaml
+fi
+
 mkdir -p "${MANIFEST_DIR}"
-cp -rf assets/* "${MANIFEST_DIR}"
+cp -f assets/kairos-operator.yaml "${MANIFEST_DIR}"


### PR DESCRIPTION
# Context

While trying to deploy kairos-operator in our air-gapped environment, we ran into issues when trying to run `NodeOp` and `NodeOpUpgrade` due to there being hard-coded references to images from public registries that the host wasn't able to reach.

This PR accompanies https://github.com/kairos-io/kairos-operator/pull/86

# Description

This PR allows users to specify overrides for various container images in their cloud-config. Specifically:

- Allows users to specify overrides for `operator` (the kairos-operator image itself), `nodeLabeler` (for the `operator-node-labeler` image), `sentinel` (for sentinel containers), and `nodeOpDefault` (the default images for `NodeOp`)
- These overrides can be specified in the cloud-config under `kairosOperator:`
- They are applied at bundle install time by running a second `kubectl kustomize`

# Design

After considering many different approaches, the one I decided was cleanest was to have some additional kustomization overlays that we copy into the bundle container then apply at install time. This way, we didn't need to make any backwards-incompatible changes to the kairos-operator manifest itself, and it also avoided (what I thought were) more brittle `sed`-based approaches where we directly manipulate the generated (at build time) manifest itself.

To avoid using heredocs for these overlays in the `run.sh` (I thought that was less readable), I created "template" files that get copied into the bundle container at build time, then their placeholders get replaced (that way we only run `sed` on these overlays, not the whole manifest). Env var overlays are generated at install time from a shared template (`env-var-image.yaml`), while `operator-image.yaml` patches the container image directly.

This design does mean that we need to copy `kubectl` to the container bundle; in our case this is not a big deal, but not sure if this could be a dealbreaker in more resource constrained scenarios.

In any case, I am very much open to taking a different approach, this was just what I was able to come up with!

# Testing

Images are correctly overridden with the following cloud-config section:
```yaml
kairosOperator:
  images:
    operator: <our_internal_url>
    nodeLabeler: <our_internal_url>
    nodeOpDefault: <our_internal_url>
    sentinel: <our_internal_url>
```

Per the description in the PR linked above, I then ran several `NodeOp` and `NodeOpUpgrade` manual tests.